### PR TITLE
[11.0][FIX] invoice cannot be saved due to missing string on translation

### DIFF
--- a/addons/purchase/i18n/ja.po
+++ b/addons/purchase/i18n/ja.po
@@ -1860,7 +1860,7 @@ msgstr "このノートは購買オーダに表示されます。"
 #: code:addons/purchase/models/account_invoice.py:218
 #, python-format
 msgid "This vendor bill has been created from: %s"
-msgstr "この仕入請求書は右の注文書から作成されています："
+msgstr "この仕入請求書は次の注文書から作成されています：%s"
 
 #. module: purchase
 #: code:addons/purchase/models/account_invoice.py:232


### PR DESCRIPTION
[3559](https://www.quartile.co/web?db=quartile&token=dMRr78CMkEX6gyy9nTiv#id=3559&action=771&model=project.task&view_type=form&menu_id=505)